### PR TITLE
fix: spelling in url_purl.py and purl2cd.py

### DIFF
--- a/purltools/purl2cd.py
+++ b/purltools/purl2cd.py
@@ -27,7 +27,7 @@ def purl2clearlydefined(purl: str) -> str | None:
 
     Raises:
         ValueError: If the provided purl is not valid, cannot be parsed by the
-        PackageURL module, or of the package type is not supported.
+        PackageURL module, or if the package type is not supported.
     """
     try:
         p = PackageURL.from_string(purl)

--- a/purltools/url_purl.py
+++ b/purltools/url_purl.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Convert between PackageURL and URL. Taken more or less unmodifed from
+"""Convert between PackageURL and URL. Taken more or less unmodified from
 packageurl."""
 
 from packageurl.contrib import purl2url, url2purl


### PR DESCRIPTION
- unmodif**ie**d
- or **if** the package